### PR TITLE
Refactor dataset URL mapping

### DIFF
--- a/progenomes/cli/download.py
+++ b/progenomes/cli/download.py
@@ -1,94 +1,69 @@
-from tqdm import tqdm
-import time
-import urllib.request
+from collections import namedtuple
 from typing import Union
+from tqdm import tqdm
+import urllib.request
 
 GENOME_INITIAL_URL = "https://progenomes.embl.de/data"
 
-GENOME_URL_MAPPING = [
-    {
-        "name": "representative-genomes",
-        "type": "representatives",
-        "server-prefix": "repGenomes",
-        "file-prefix": "progenomes3",
-        "filetype": "fasta.bz2",
-        "order": "target.type",
-    },
-    {
-        "name": "aquatic",
-        "type": "aquatic",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "disease-associated",
-        "type": "disease-associated",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "food-associated",
-        "type": "food-associated",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "freshwater",
-        "type": "freshwater",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "host-associated",
-        "type": "host-associated",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "host-plant-associated",
-        "type": "host-plant-associated",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "sediment-mud",
-        "type": "sediment-mud",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-    {
-        "name": "mud",
-        "type": "mud",
-        "server-prefix": "habitats",
-        "file-prefix": "representatives",
-        "filetype": "fasta.gz",
-        "order": "type.target",
-    },
-]
+UrlData = namedtuple(
+    "UrlData", ["type", "server_prefix", "file_prefix", "filetype", "order"]
+)
+
+DatasetUrlData = namedtuple(
+    "DatasetUrlData", ["file_prefix", "filename", "filetype", "headers"]
+)
+
+GENOME_URL_MAPPING = {
+    "representative-genomes": UrlData(
+        "representatives", "repGenomes", "progenomes3", "fasta.bz2", "target.type"
+    ),
+    "aquatic": UrlData(
+        "aquatic", "habitats", "representatives", "fasta.gz", "type.target"
+    ),
+    "disease-associated": UrlData(
+        "disease-associated",
+        "habitats",
+        "representatives",
+        "fasta.gz",
+        "type.target",
+    ),
+    "food-associated": UrlData(
+        "food-associated", "habitats", "representatives", "fasta.gz", "type.target"
+    ),
+    "freshwater": UrlData(
+        "freshwater", "habitats", "representatives", "fasta.gz", "type.target"
+    ),
+    "host-associated": UrlData(
+        "host-associated", "habitats", "representatives", "fasta.gz", "type.target"
+    ),
+    "host-plant-associated": UrlData(
+        "host-plant-associated",
+        "habitats",
+        "representatives",
+        "fasta.gz",
+        "type.target",
+    ),
+    "sediment-mud": UrlData(
+        "sediment-mud", "habitats", "representatives", "fasta.gz", "type.target"
+    ),
+    "mud": UrlData("mud", "habitats", "representatives", "fasta.gz", "type.target"),
+}
 
 
 def process_genome_url(target: str, component: str):
-    mapping = next(iter(item for item in GENOME_URL_MAPPING if item["name"] == target))
-    if mapping["order"] == "type.target":
-        return f"{GENOME_INITIAL_URL}/{mapping['server-prefix']}/{mapping['file-prefix']}.{mapping['type'].replace('-', '_')}.{component}.{mapping['filetype']}"
+    mapping = GENOME_URL_MAPPING[target]
+    if mapping.order == "type.target":
+        return (
+            f"{GENOME_INITIAL_URL}/{mapping.server_prefix}/{mapping.file_prefix}."
+            f"{mapping.type.replace('-', '_')}.{component}.{mapping.filetype}"
+        )
     else:
-        return f"{GENOME_INITIAL_URL}/{mapping['server-prefix']}/{mapping['file-prefix']}.{component}.{mapping['type'].replace('-', '_')}.{mapping['filetype']}"
+        return (
+            f"{GENOME_INITIAL_URL}/{mapping.server_prefix}/{mapping.file_prefix}."
+            f"{component}.{mapping.type.replace('-', '_')}.{mapping.filetype}"
+        )
 
-def download_genomes(target:str, components: list[str]):
+def download_genomes(target: str, components: list[str]):
     pbar = tqdm(components)
     for t in pbar:
         pbar.set_description(f"Downloading {t}")
@@ -98,90 +73,48 @@ def download_genomes(target:str, components: list[str]):
 
 DATASET_INITIAL_URL = "https://progenomes.embl.de/data"
 
-DATASET_URL_MAPPING = [
-    {
-        "name": "habitats-per-isolate",
-        "file-prefix": "proGenomes3",
-        "filename": "habitat_isolates",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "habitats-per-speci-cluster",
-        "file-prefix": "proGenomes3",
-        "filename": "habitat_specI",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "representatives-per-speci-cluster",
-        "file-prefix": "proGenomes3",
-        "filename": "representatives_for_each_specI",
-        "filetype": "tsv.gz",
-        "headers": False,
-    },
-    {
-        "name": "marker-genes",
-        "file-prefix": "proGenomes3",
-        "filename": "markerGenes",
-        "filetype": "tar.gz",
-    },
-    {
-        "name": "speci-clustering-data",
-        "file-prefix": "proGenomes3",
-        "filename": "specI_clustering",
-        "filetype": "tab.bz2",
-        "headers": False,
-    },
-    {
-        "name": "gtdb-taxonomy",
-        "file-prefix": "proGenomes3",
-        "filename": "specI_lineageGTDB",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "highly-important-strains",
-        "file-prefix": None,
-        "filename": "highly_important_strains",
-        "filetype": "tab.bz2",
-        "headers": False,
-    },
-    {
-        "name": "excluded-genomes",
-        "file-prefix": "proGenomes3",
-        "filename": "excluded_genomes",
-        "filetype": "txt.bz2",
-    },
-    {
-        "name": "mge-orfs",
-        "file-prefix": "representatives",
-        "filename": "mge_ORFS",
-        "filetype": "tsv.bz2",
-        "headers": True,
-    },
-    {
-        "name": "mge-annotation",
-        "file-prefix": "representatives",
-        "filename": "mge_annotation",
-        "filetype": "tsv.bz2",
-        "headers": True,
-    },
-    {
-        "name": "gecco-gene-clusters",
-        "file-prefix": "proGenomes3",
-        "filename": "gecco_clusters",
-        "filetype": "gbk.gz",
-    },
-]
+DATASET_URL_MAPPING = {
+    "habitats-per-isolate": DatasetUrlData(
+        "proGenomes3", "habitat_isolates", "tab.bz2", True
+    ),
+    "habitats-per-speci-cluster": DatasetUrlData(
+        "proGenomes3", "habitat_specI", "tab.bz2", True
+    ),
+    "representatives-per-speci-cluster": DatasetUrlData(
+        "proGenomes3", "representatives_for_each_specI", "tsv.gz", False
+    ),
+    "marker-genes": DatasetUrlData("proGenomes3", "markerGenes", "tar.gz", None),
+    "speci-clustering-data": DatasetUrlData(
+        "proGenomes3", "specI_clustering", "tab.bz2", False
+    ),
+    "gtdb-taxonomy": DatasetUrlData(
+        "proGenomes3", "specI_lineageGTDB", "tab.bz2", True
+    ),
+    "highly-important-strains": DatasetUrlData(
+        None, "highly_important_strains", "tab.bz2", False
+    ),
+    "excluded-genomes": DatasetUrlData(
+        "proGenomes3", "excluded_genomes", "txt.bz2", None
+    ),
+    "mge-orfs": DatasetUrlData("representatives", "mge_ORFS", "tsv.bz2", True),
+    "mge-annotation": DatasetUrlData(
+        "representatives", "mge_annotation", "tsv.bz2", True
+    ),
+    "gecco-gene-clusters": DatasetUrlData(
+        "proGenomes3", "gecco_clusters", "gbk.gz", None
+    ),
+}
 
 
 def process_dataset_url(item: str):
-    mapping = next(iter(i for i in DATASET_URL_MAPPING if i["name"] == item))
-    if mapping["file-prefix"] is None:
-        return f"{DATASET_INITIAL_URL}/{mapping['filename']}.{mapping['filetype']}"
+    mapping = DATASET_URL_MAPPING[item]
+    if mapping.file_prefix is None:
+        return f"{DATASET_INITIAL_URL}/{mapping.filename}.{mapping.filetype}"
     else:
-        return f"{DATASET_INITIAL_URL}/{mapping['file-prefix']}_{mapping['filename']}.{mapping['filetype']}"
+        return (
+            f"{DATASET_INITIAL_URL}/{mapping.file_prefix}_{mapping.filename}."
+            f"{mapping.filetype}"
+        )
 
 def download_dataset(target:str):
     url = process_dataset_url(target)


### PR DESCRIPTION
## Summary
- replace the list of genome URL metadata dictionaries with a namedtuple-based mapping for direct access
- update the genome URL generation helper to use the new mapping structure and clean up imports
- convert dataset metadata mapping to a namedtuple-backed dictionary for consistent access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df5194cc508333b6e3681d2295c153