### PR TITLE
Refactor URL mapping to dictionary of namedtuples

### DIFF
--- a/progenomes/cli/view.py
+++ b/progenomes/cli/view.py
@@ -1,79 +1,71 @@
+from collections import namedtuple
+
 INITIAL_URL = "https://progenomes.embl.de/data"
 
-URL_MAPPING = [
-    {
-        "name": "habitats-per-isolate",
-        "file-prefix": "proGenomes3",
-        "filename": "habitat_isolates",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "habitats-per-speci-cluster",
-        "file-prefix": "proGenomes3",
-        "filename": "habitat_specI",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "representatives-per-speci-cluster",
-        "file-prefix": "proGenomes3",
-        "filename": "representatives_for_each_specI",
-        "filetype": "tsv.gz",
-        "headers": False,
-    },
-    {
-        "name": "speci-clustering-data",
-        "file-prefix": "proGenomes3",
-        "filename": "specI_clustering",
-        "filetype": "tab.bz2",
-        "headers": False,
-    },
-    {
-        "name": "gtdb-taxonomy",
-        "file-prefix": "proGenomes3",
-        "filename": "specI_lineageGTDB",
-        "filetype": "tab.bz2",
-        "headers": True,
-    },
-    {
-        "name": "highly-important-strains",
-        "file-prefix": None,
-        "filename": "highly_important_strains",
-        "filetype": "tab.bz2",
-        "headers": False,
-    },
-    {
-        "name": "mge-orfs",
-        "file-prefix": "representatives",
-        "filename": "mge_ORFS",
-        "filetype": "tsv.bz2",
-        "headers": True,
-    },
-    {
-        "name": "mge-annotation",
-        "file-prefix": "representatives",
-        "filename": "mge_annotation",
-        "filetype": "tsv.bz2",
-        "headers": True,
-    },
-]
+URLMapping = namedtuple("URLMapping", ["file_prefix", "filename", "filetype", "headers"])
+
+URL_MAPPING = {
+    "habitats-per-isolate": URLMapping(
+        file_prefix="proGenomes3",
+        filename="habitat_isolates",
+        filetype="tab.bz2",
+        headers=True,
+    ),
+    "habitats-per-speci-cluster": URLMapping(
+        file_prefix="proGenomes3",
+        filename="habitat_specI",
+        filetype="tab.bz2",
+        headers=True,
+    ),
+    "representatives-per-speci-cluster": URLMapping(
+        file_prefix="proGenomes3",
+        filename="representatives_for_each_specI",
+        filetype="tsv.gz",
+        headers=False,
+    ),
+    "speci-clustering-data": URLMapping(
+        file_prefix="proGenomes3",
+        filename="specI_clustering",
+        filetype="tab.bz2",
+        headers=False,
+    ),
+    "gtdb-taxonomy": URLMapping(
+        file_prefix="proGenomes3",
+        filename="specI_lineageGTDB",
+        filetype="tab.bz2",
+        headers=True,
+    ),
+    "highly-important-strains": URLMapping(
+        file_prefix=None,
+        filename="highly_important_strains",
+        filetype="tab.bz2",
+        headers=False,
+    ),
+    "mge-orfs": URLMapping(
+        file_prefix="representatives",
+        filename="mge_ORFS",
+        filetype="tsv.bz2",
+        headers=True,
+    ),
+    "mge-annotation": URLMapping(
+        file_prefix="representatives",
+        filename="mge_annotation",
+        filetype="tsv.bz2",
+        headers=True,
+    ),
+}
 
 
 def get_url(item: str):
-    for mapping in URL_MAPPING:
-        if mapping["name"] == item:
-            break
+    try:
+        mapping = URL_MAPPING[item]
+    except KeyError as exc:
+        raise ValueError(f"Item '{item}' not found in URL mapping.") from exc
+    if mapping.file_prefix is None:
+        path = f"{mapping.filename}.{mapping.filetype}"
     else:
-        raise ValueError(f"Item '{item}' not found in URL mapping.")
-    mapping = next(iter(i for i in URL_MAPPING if i["name"] == item), None)
-    if mapping["file-prefix"] is None:
-        path = f"{mapping['filename']}.{mapping['filetype']}"
-    else:
-        path = f"{mapping['file-prefix']}_{mapping['filename']}.{mapping['filetype']}"
-    return (
-        f"{INITIAL_URL}/{path}", mapping["filetype"],
-    )
+        path = f"{mapping.file_prefix}_{mapping.filename}.{mapping.filetype}"
+    return (f"{INITIAL_URL}/{path}", mapping.filetype)
 
 
 def view(target):


### PR DESCRIPTION
## Summary
- replace the view URL mapping list of dictionaries with a dictionary of URLMapping namedtuples for direct lookup
- simplify get_url to use dictionary access while preserving missing-item validation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df54570d0c8333a53ad162a0e55942